### PR TITLE
Corrige erro na comparação br vs pt

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ extenso('42', { negative: 'informal' }) // 'menos quarenta e dois'
 
 A escrita de alguns números pode váriar de país para país (e talvez até de
 região para região), por exemplo, o número 16 é escrito *dezesseis* no Brasil,
-enquanto que em Portugal é escrito *dezassete*. A configuração dessas
+enquanto que em Portugal é escrito *dezasseis*. A configuração dessas
 diferenças é feita aqui.
 
 - `br` (*valor padrão*) - Para escrever no dialeto do Brasil.


### PR DESCRIPTION
a descrição entre `pt-BR` e `pt-PT` estava apontando para números diferentes (16 vs 17 respectivamente)