### PR TITLE
Adicionar a opção para escolher a escala numérica a ser usada

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ retornará um erro.
 
 - `mode` - *string*
 - `locale` - *string*
+- `scale` - *string*
 - `negative` - *string*
 - `currency` - *object*
 - `currency.type` - *string*
@@ -127,6 +128,20 @@ diferenças é feita aqui.
 extenso('16') // 'dezesseis'
 extenso('16', { locale: 'br' }) // 'dezesseis'
 extenso('16', { locale: 'pt' }) // 'dezasseis'
+```
+
+#### `scale`
+
+> Define a escala numérica a ser usada.
+
+- `long` (*valor padrão*) - Números superiores a um milhão terão um novo termo a cada 1.000.000 vezes em relação ao termo anterior.
+- `short` - Números superiores a um milhão terão um novo termo a cada 1.000 vezes em relação ao termo anterior.
+
+##### Exemplo
+
+```js
+extenso('1000000000', { locale: 'pt' }) // 'mil milhões'
+extenso('1000000000', { locale: 'pt', scale: 'short' }) // 'um bilião'
 ```
 
 #### `currency.type`

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ extenso('16', { locale: 'pt' }) // 'dezasseis'
 
 > Define a escala numérica a ser usada.
 
-- `long` (*valor padrão*) - Números superiores a um milhão terão um novo termo a cada 1.000.000 vezes em relação ao termo anterior.
+- `long` (*valor padrão, com exeção em `{ locale: 'br' }`*) - Números superiores a um milhão terão um novo termo a cada 1.000.000 vezes em relação ao termo anterior.
 - `short` - Números superiores a um milhão terão um novo termo a cada 1.000 vezes em relação ao termo anterior.
 
 ##### Exemplo

--- a/src/gt1000/index.js
+++ b/src/gt1000/index.js
@@ -7,10 +7,20 @@ import { name, clear, singularize, addConjunction, addComma, write } from './par
  * @function gt1000
  * @param {string} int Número inteiro maior que mil.
  * @param {string} locale Código do país para escrever o número.
+ * @param {string} [scale='long'] Escala numérica a ser usada.
  * @returns {number} Valor escrito por extenso.
  */
-export default (int, locale) => {
-  const number = write(addComma(addConjunction(singularize(clear(name(split(int), locale))), int)), locale)
+export default (int, locale, scale='long') => {
+  const number = write(
+    addComma(
+      addConjunction(
+        singularize(clear(name(split(int, scale), locale, scale))),
+        int
+      )
+    ),
+    locale,
+    scale
+  );
 
   return number.join(' ')
 }

--- a/src/gt1000/index.test.js
+++ b/src/gt1000/index.test.js
@@ -25,5 +25,15 @@ test('Deve escrever números maiores que mil', (t) => {
   t.is(gt1000('2001001', 'br'),    'dois milhões, mil e um')
   t.is(gt1000('2001100', 'br'),    'dois milhões, mil e cem')
   t.is(gt1000('2001101', 'br'),    'dois milhões, mil cento e um')
-  t.is(gt1000('2000001101', 'pt'), 'dois biliões, mil cento e um')
+})
+
+test('Deve escrever números maiores que mil e diferenciar as escalas numéricas', (t) => {
+  t.is(gt1000('2001101', 'br'),                'dois milhões, mil cento e um')
+  t.is(gt1000('2001101', 'br', 'short'),       'dois milhões, mil cento e um')
+
+  t.is(gt1000('2000001101', 'pt'),             'dois mil milhões, mil cento e um')
+  t.is(gt1000('2000001101', 'pt', 'short'),    'dois biliões, mil cento e um')
+
+  t.is(gt1000('1000000000000', 'pt'),          'um bilião')
+  t.is(gt1000('1000000000000', 'pt', 'short'), 'um trilião')
 })

--- a/src/gt1000/int-util.js
+++ b/src/gt1000/int-util.js
@@ -5,12 +5,38 @@ import formatNumber from 'format-number'
  *
  * @method split
  * @param {string} int Número inteiro.
+ * @param {string} [scale='short'] Escala numérica a ser usada.
+ * @param {boolean} [space='false'] Adicionar espaco na separação de escala longa
  * @returns {Array} Array com as partes do número.
  */
-export const split = (int) => {
+
+export const split = (int, scale = 'short', space=false) => {
   const format = formatNumber()
   const formatted = format(int)
   const splitted = formatted.split(',')
+
+  // > Para números naturais inferiores a 10^9, as escalas são idênticas.
+  // > Para números iguais ou superiores a 10^9, as duas escalas divergem ao usar
+  //   as mesmas palavras para diferentes valores (fonte: Wikipedia)
+
+  if (scale === 'long') {
+    return splitted
+      .reverse() // [ '000', '000', '000', '1' ]
+
+      .map((item, index, arr) => {
+        if (index < 2 || (index == arr.length - 1 && index % 2 == 0)) {
+          return item;
+        } else if ((index - 1) % 2 == 0) {
+          
+          return space ? `${item} ${arr[index - 1]}` : `${item}${arr[index - 1]}`;
+        }
+      }) // [ '000', '000', undefined, '1 000' ]
+
+      .filter(item => item) // [ '000', '000', '1 000' ]
+
+      .reverse();
+    // // [ '1 000', '000', '000' ]
+  }
 
   return splitted
 }
@@ -29,4 +55,3 @@ export const getLastNumber = (int) => {
 
   return integer
 }
-

--- a/src/gt1000/int-util.test.js
+++ b/src/gt1000/int-util.test.js
@@ -4,13 +4,20 @@ import { split, getLastNumber } from './int-util'
 /**
  * Função: split
  */
-test('Deve separar as partes de um número', (t) => {
-  t.deepEqual(split('1'),       [ '1' ])
-  t.deepEqual(split('10'),      [ '10' ])
-  t.deepEqual(split('100'),     [ '100' ])
-  t.deepEqual(split('1000'),    [ '1', '000' ])
-  t.deepEqual(split('1000000'), [ '1', '000', '000' ])
-})
+test('Deve separar as partes de um número', t => {
+  t.deepEqual(split(10 ** 0),          ['1']);
+  t.deepEqual(split(10 ** 1),          ['10']);
+  t.deepEqual(split(10 ** 2),          ['100']);
+  t.deepEqual(split(10 ** 3),          ['1', '000']);
+  t.deepEqual(split(10 ** 6),          ['1', '000', '000']);
+  t.deepEqual(split(10 ** 6, 'long'),  ['1', '000', '000']);
+
+  t.deepEqual(split(10 ** 9, 'long'),        ['1000', '000', '000']);
+  t.deepEqual(split(10 ** 9, 'long', true),  ['1 000', '000', '000']);
+  t.deepEqual(split(10 ** 10, 'long', true), ['10 000', '000', '000']);
+  t.deepEqual(split(10 ** 11, 'long', true), ['100 000', '000', '000']);
+  t.deepEqual(split(10 ** 12, 'long', true), ['1', '000 000', '000', '000']);
+});
 
 /**
  * Função: getLastNumber

--- a/src/gt1000/parts-util.js
+++ b/src/gt1000/parts-util.js
@@ -1,7 +1,8 @@
 import reverse from '@arr/reverse'
-import { getLastNumber } from './int-util'
+import { getLastNumber, split } from './int-util'
 import { listGt1000 as getList } from '../get-list'
 import lt1000 from '../lt1000'
+import gt1000 from '.'
 
 /**
  * Adicionar vírgula entre algumas partes.
@@ -36,9 +37,9 @@ export const addConjunction = (parts, int) => {
   // - Caso 2: A parte é um inteiro divisível por cem.
   if (lastNum < 100 || lastNum % 100 === 0) {
     return parts.map((part, index, array) => {
-      return index === array.length - 2
-        ? `${part} e`
-        : part
+      return index === array.length - 2 
+      ? `${part} e`
+      : part
     })
   }
 
@@ -53,14 +54,14 @@ export const addConjunction = (parts, int) => {
  * @returns {Array} Partes com algumas partes removidas.
  */
 export const clear = (parts) => {
-
   // Etapas para a remoção:
   // - Etapa 1: Remove zeros à esquerda.
   // - Etapa 2: Remove partes que não são lidas.
   // - Etapa 3: Remove o "1" das partes com "1 mil".
   return parts
-    .map(part => part.replace(/^0+\s?/, ''))
-    .filter(part => /^\d/.test(part))
+    .map(part => part.replace(/^0+\s?/, '-').trim())
+    .filter(part => (part.split(' ').length > 1 || parseInt(part) == part || /^\d/.test(part)))
+    .map(part => part.replace(/\-/g, ''))
     .map(part => part.replace(/^1\s(mil)$/, '$1'))
 }
 
@@ -72,14 +73,20 @@ export const clear = (parts) => {
  * @param {string} locale Código do país para escrever o número.
  * @returns {Array} Partes com os inteiros escritos por extenso.
  */
-export const name = (parts, locale) => {
-  return reverse(reverse(parts).map((part, i) => {
-    const numberName = getList(locale)[i - 1]
-
-    return numberName
-      ? `${part} ${numberName}`
-      : part
-  }))
+export const name = (parts, locale, scale) => {
+  return reverse(
+    reverse(parts)
+      .map(part => {
+        if (split(part).length > 1) {
+          return gt1000(part, locale, scale);
+        }
+        return part;
+      })
+      .map((part, i) => {
+        const numberName = getList(locale)[i - 1];
+        return numberName ? `${part} ${numberName}` : part;
+      })
+  )
 }
 
 /**
@@ -104,12 +111,12 @@ export const singularize = (parts) => {
  * @param {string} locale Código do país para escrever o número.
  * @returns {string} Número como todas as partes escritas por extenso.
  */
-export const write = (parts, locale) => {
+export const write = (parts, locale, scale) => {
   return parts.map(part => {
     return part.replace(/^(\d+)/, digit => {
       const int = parseInt(digit)
 
-      return lt1000(int, locale)
+      return int < 1000 ? lt1000(int, locale) : gt1000(int, locale, scale)
     })
   })
 }

--- a/src/gt1000/parts-util.test.js
+++ b/src/gt1000/parts-util.test.js
@@ -23,9 +23,10 @@ test('Deve adicionar "e" no final de algumas partes', (t) => {
  * Função: clear
  */
 test('Deve trechos em partes que não são lidos', (t) => {
-  t.deepEqual(clear([ '2 milhões', '042 mil', '001' ]), [ '2 milhões', '42 mil', '1' ])
-  t.deepEqual(clear([ '2 milhões', '000 mil', '000' ]), [ '2 milhões' ])
-  t.deepEqual(clear([ '1 mil' ]),                       [ 'mil' ])
+  t.deepEqual(clear([ 'mil bilhões', ' milhões', '000 mil', '000' ]), [ 'mil bilhões' ])
+  t.deepEqual(clear([ '2 milhões', '042 mil', '001' ]),               [ '2 milhões', '42 mil', '1' ])
+  t.deepEqual(clear([ '2 milhões', '000 mil', '000' ]),               [ '2 milhões' ])
+  t.deepEqual(clear([ '1 mil' ]),                                     [ 'mil' ])
 })
 
 /**
@@ -35,6 +36,7 @@ test('Deve adicionar o nome de cada parte', (t) => {
   t.deepEqual(name([ '1', '000', '000' ], 'br'),        [ '1 milhões', '000 mil', '000' ])
   t.deepEqual(name([ '1', '000' ], 'br'),               [ '1 mil', '000' ])
   t.deepEqual(name([ '1', '000', '000', '000' ], 'pt'), [ '1 biliões', '000 milhões', '000 mil', '000' ])
+  t.deepEqual(name([ '2000', '000', '000' ], 'pt'),     [ 'dois mil milhões', '000 mil', '000' ])
 })
 
 /**

--- a/src/write-all.js
+++ b/src/write-all.js
@@ -37,7 +37,7 @@ export const toNegative = (num, mode = 'formal') => {
  * @param {object} opts Opções para configurar modo de escrita.
  * @returns {string} Número escrito por extenso.
  */
-export default (num, opts) => {
+export default (num, opts = {}) => {
   if (typeof num !== 'string' && typeof num !== 'number') {
     throw new TypeError('Must be a string or a number')
   }
@@ -51,6 +51,7 @@ export default (num, opts) => {
   let defaultOpts = {
     mode: 'number',
     locale: 'br',
+    scale: 'long',
     negative: 'formal',
     currency: {
       type: 'BRL'
@@ -69,6 +70,7 @@ export default (num, opts) => {
   if (
        !isValidOpt(opts.mode, [ 'number', 'currency' ])
     || !isValidOpt(opts.locale, [ 'pt', 'br' ])
+    || !isValidOpt(opts.scale, [ 'long', 'short' ])
     || !isValidOpt(opts.negative, [ 'formal', 'informal' ])
     || !isValidOpt(opts.currency.type, [ 'BRL', 'EUR', 'ECV' ])
     || !isValidOpt(opts.number.gender, [ 'm', 'f' ])
@@ -82,7 +84,7 @@ export default (num, opts) => {
   if (opts.mode === 'currency') {
     const iso = opts.currency.type
     const locale = opts.locale
-    const numText = writeCurrency(iso, locale, integer, decimal)
+    const numText = writeCurrency(iso, locale, integer, decimal, opts.scale)
 
     return isNegative
       ? toNegative(numText, opts.negative)
@@ -92,7 +94,7 @@ export default (num, opts) => {
   if (opts.mode === 'number') {
     const intNameSingular = opts.number.gender === 'f' ? 'inteira' : 'inteiro'
     const intName = parseInt(integer) === 1 ? intNameSingular : `${intNameSingular}s`
-    const intText = writeInt(integer, opts.locale, opts.number.gender)
+    const intText = writeInt(integer, opts.locale, opts.number.gender, opts.scale)
     const decText = writeDecimal(decimal, opts.locale, opts.number.decimal)
 
     // Se tem a parte inteira e não tem a parte decimal

--- a/src/write-all.js
+++ b/src/write-all.js
@@ -61,6 +61,11 @@ export default (num, opts = {}) => {
       decimal: 'formal'
     }
   }
+  
+  // a escala longa é a padrão, com excessão ao Brasil se `opts.scale` não for definido
+  if (opts.scale === undefined  && (opts.locale == undefined || opts.locale == 'br')) {
+    opts.scale = 'short'
+  }
 
   // Usando o pacote 'assign-deep' no lugar de Object.assign(),
   // pois esse último substitui completamente todas as propriedades

--- a/src/write-currency/index.js
+++ b/src/write-currency/index.js
@@ -47,9 +47,10 @@ export const isZero = (val) => {
  * @param {string} locale Código do país para escrever o número.
  * @param {string} [unit='0'] Valor da moeda (parte inteira).
  * @param {string} [subunit='0'] Sub-unidade do valor (parte "decimal").
+ * @param {string} [scale='long'] Escala numérica a ser usada.
  * @returns {string} Valor escrito por extenso.
  */
-export default (iso, locale, unit = '0', subunit = '0') => {
+export default (iso, locale, unit = '0', subunit = '0', scale='long') => {
   if (!isValidIso(iso, allCurrencies)) {
     throw new Error('Invalid ISO code')
   }
@@ -59,8 +60,8 @@ export default (iso, locale, unit = '0', subunit = '0') => {
   }
 
   const opts = allCurrencies[iso]
-  const unitText = write(unit, locale, opts)
-  const subunitText = writeSubunit(subunit, locale, opts)
+  const unitText = write(unit, locale, opts, scale)
+  const subunitText = writeSubunit(subunit, locale, opts, scale)
 
   if (isZero(unit)) return subunitText
   if (isZero(subunit)) return unitText

--- a/src/write-currency/write-subunit.js
+++ b/src/write-currency/write-subunit.js
@@ -7,10 +7,11 @@ import writeInt from '../write-int'
  * @param {string} val Valor a ser escrito.
  * @param {string} locale Código do país para escrever o número.
  * @param {object} opts Opções de escrita do valor.
+ * @param {string} [scale='long'] Escala numérica a ser usada.
  * @returns {string} Valor escrito por extenso.
  */
-export default (val, locale, opts) => {
-  const textNumber = writeInt(val, locale)
+export default (val, locale, opts, scale='long') => {
+  const textNumber = writeInt(val, locale, undefined, scale)
 
   return parseInt(val) === 1
     ? `${textNumber} ${opts.subunit.singular}`

--- a/src/write-currency/write.js
+++ b/src/write-currency/write.js
@@ -7,12 +7,12 @@ import writeInt from '../write-int'
  * @param {string} val O valor a ser escrito.
  * @param {string} locale Código do país para escrever o número.
  * @param {object} opts As opções de escrita do valor.
+ * @param {string} [scale='long'] Escala numérica a ser usada.
  * @returns {string} O valor escrito por extenso.
  */
-export default (val, locale, opts) => {
+export default (val, locale, opts, scale='long') => {
   const number = parseInt(val)
-  const text = writeInt(val, locale)
-
+  const text = writeInt(val, locale, undefined, scale)
   if (number === 1) return `${text} ${opts.singular}`
   if (number >= 1e+6) return `${text} de ${opts.plural}`
 

--- a/src/write-int.js
+++ b/src/write-int.js
@@ -24,15 +24,16 @@ export const toFemale = (num) => {
  * @param {string} int Um número para ser escrito.
  * @param {string} locale Código do país para escrever o número.
  * @param {string} [gender='m'] A opção do gênero do número.
+ * @param {string} [scale='long'] A escala numérica a ser usada.
  * @returns {string} O número escrito.
  */
-export default (int, locale, gender = 'm') => {
+export default (int, locale, gender = 'm', scale = 'long') => {
   const intNum = parseInt(int)
   let num
 
   if (intNum < 1000) num = lt1000(intNum, locale)
   if (intNum === 1000) num = 'mil'
-  if (intNum > 1000) num = gt1000(int, locale)
+  if (intNum > 1000) num = gt1000(int, locale, scale)
 
   return gender === 'f'
     ? toFemale(num)


### PR DESCRIPTION
## Implementação:
- A função `split` agora aceita um novo parâmetro, `scale`.  Se `scale` for igual a "long", 
  o que antes era dividido em ['1', 000', '000', '000'] agora será ['1 000', '000', '000']
 
- Se a função `name` receber um array em que algum item seja maior de que três algarismos (como no caso anterior), ele irá chamar recursivamente função `gt1000`, até que todos os parâmetros sejam menores que mil.

Acredito que resumidamente seja isso. Eu tentei manter ao máximo o estilo já presente no código. Caso veja algo diferente, saiba que foi o meu editor de texto ;)

----

Referente a issue #19 