### PR TITLE
Incluir metical nos exemplos

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ extenso('42', { mode: 'currency' }) // 'quarenta e dois reais'
 extenso('42', { mode: 'currency', currency: { type: 'BRL' } }) // 'quarenta e dois reais'
 extenso('42', { mode: 'currency', currency: { type: 'EUR' } }) // 'quarenta e dois euros'
 extenso('42', { mode: 'currency', currency: { type: 'ECV' } }) // 'quarenta e dois escudos'
+extenso('42', { mode: 'currency', currency: { type: 'MZN' } }) // 'quarenta e dois meticais'
 ```
 
 #### `number.gender`


### PR DESCRIPTION
O que mudou?
=========================
Este commit adiciona um exemplo usando meticais de modo a mostrar que a biblioteca permite formatação de valores monetários em meticais

Porque estamos fazendo isso?
========================
Não encontrei algo na documentação que indicasse que a biblioteca suporta a exibição de valores numéricos em meticais.