### PR TITLE
Adiciona opção de escala curta e longa

### DIFF
--- a/src/get-list.js
+++ b/src/get-list.js
@@ -78,22 +78,43 @@ export const listLt1000 = (locale) => {
  * @param {string} locale Código do país que deve ser escrito.
  * @returns {Array} Lista das partes do número.
  */
-export const listGt1000 = (locale) => { 
-  return [
+export const listGt1000 = (locale, scale='short') => {
+  const baseList = [
     'mil',
     'milhões',
-    ({ br: 'bilhões', pt: 'biliões' })[locale],
-    ({ br: 'trilhões', pt: 'triliões' })[locale],
-    ({ br: 'quatrilhões', pt: 'quatriliões' })[locale],
-    ({ br: 'quintilhões', pt: 'quintiliões' })[locale],
-    ({ br: 'sextilhões', pt: 'sextiliões' })[locale],
-    ({ br: 'septilhões', pt: 'septiliões' })[locale],
-    ({ br: 'octilhões', pt: 'octiliões' })[locale],
-    ({ br: 'nonilhões', pt: 'noniliões' })[locale],
-    ({ br: 'decilhões', pt: 'deciliões' })[locale],
-    ({ br: 'undecilhões', pt: 'undeciliões' })[locale],
-    ({ br: 'duodecilhões', pt: 'duodeciliões' })[locale]
+
+    // Sem o sufixo, pois ele será dinâmico
+    'bil',
+    'tril',
+    'quatril',
+    'quintil',
+    'sextil',
+    'septil',
+    'octil',
+    'nonil',
+    'decil',
+    'undecil',
+    'duodecil'
   ]
+
+  return baseList
+    .map((value, index) => { // Resolve sufixo entre 'br' e 'pt'
+      if (index < 2) return value
+      const suffixes = {
+        'br': 'hões',
+        'pt': 'iões'
+      }
+      return value + suffixes[locale]
+    })
+    .map((value, index, array) => { // Resolve escala entre longa e curta
+      if (scale === 'long') {
+        if (index < 2) return value
+        if (index % 2 == 0) return 'mil ' + array[index / 2]
+        return array[index / 2 + .5]
+      } else {
+        return value
+      }
+    })
 }
 
 /**

--- a/src/gt1000/index.js
+++ b/src/gt1000/index.js
@@ -9,8 +9,8 @@ import { name, clear, singularize, addConjunction, addComma, write } from './par
  * @param {string} locale Código do país para escrever o número.
  * @returns {number} Valor escrito por extenso.
  */
-export default (int, locale) => {
-  const number = write(addComma(addConjunction(singularize(clear(name(split(int), locale))), int)), locale)
+export default (int, locale, scale) => {
+  const number = write(addComma(addConjunction(singularize(clear(name(split(int), locale, scale))), int)), locale)
 
   return number.join(' ')
 }

--- a/src/gt1000/index.test.js
+++ b/src/gt1000/index.test.js
@@ -11,6 +11,7 @@ test('Deve escrever números maiores que mil', (t) => {
   t.is(gt1000('2001', 'br'),       'dois mil e um')
   t.is(gt1000('2100', 'br'),       'dois mil e cem')
   t.is(gt1000('2101', 'br'),       'dois mil cento e um')
+
   t.is(gt1000('1000000', 'br'),    'um milhão')
   t.is(gt1000('1000001', 'br'),    'um milhão e um')
   t.is(gt1000('1000100', 'br'),    'um milhão e cem')
@@ -26,4 +27,10 @@ test('Deve escrever números maiores que mil', (t) => {
   t.is(gt1000('2001100', 'br'),    'dois milhões, mil e cem')
   t.is(gt1000('2001101', 'br'),    'dois milhões, mil cento e um')
   t.is(gt1000('2000001101', 'pt'), 'dois biliões, mil cento e um')
+
+  t.is(gt1000('2000001101', 'br', 'short'), 'dois bilhões, mil cento e um')
+  t.is(gt1000('2000001101', 'br', 'long'),  'dois mil milhões, mil cento e um')
+
+  t.is(gt1000('2000000001101', 'pt', 'short'), 'dois triliões, mil cento e um')
+  t.is(gt1000('2000000001101', 'pt', 'long'),  'dois biliões, mil cento e um')
 })

--- a/src/gt1000/parts-util.js
+++ b/src/gt1000/parts-util.js
@@ -72,9 +72,9 @@ export const clear = (parts) => {
  * @param {string} locale Código do país para escrever o número.
  * @returns {Array} Partes com os inteiros escritos por extenso.
  */
-export const name = (parts, locale) => {
+export const name = (parts, locale, scale) => {
   return reverse(reverse(parts).map((part, i) => {
-    const numberName = getList(locale)[i - 1]
+    const numberName = getList(locale, scale)[i - 1]
 
     return numberName
       ? `${part} ${numberName}`

--- a/src/gt1000/parts-util.test.js
+++ b/src/gt1000/parts-util.test.js
@@ -35,6 +35,7 @@ test('Deve adicionar o nome de cada parte', (t) => {
   t.deepEqual(name([ '1', '000', '000' ], 'br'),        [ '1 milhões', '000 mil', '000' ])
   t.deepEqual(name([ '1', '000' ], 'br'),               [ '1 mil', '000' ])
   t.deepEqual(name([ '1', '000', '000', '000' ], 'pt'), [ '1 biliões', '000 milhões', '000 mil', '000' ])
+  t.deepEqual(name([ '1', '000', '000', '000' ], 'pt', 'long'), [ '1 mil milhões', '000 milhões', '000 mil', '000' ])
 })
 
 /**

--- a/src/write-all.js
+++ b/src/write-all.js
@@ -52,6 +52,7 @@ export default (num, opts) => {
     mode: 'number',
     locale: 'br',
     negative: 'formal',
+    scale: 'short',
     currency: {
       type: 'BRL'
     },
@@ -70,6 +71,7 @@ export default (num, opts) => {
        !isValidOpt(opts.mode, [ 'number', 'currency' ])
     || !isValidOpt(opts.locale, [ 'pt', 'br' ])
     || !isValidOpt(opts.negative, [ 'formal', 'informal' ])
+    || !isValidOpt(opts.scale, [ 'short', 'long' ])
     || !isValidOpt(opts.currency.type, [ 'BRL', 'EUR', 'ECV' ])
     || !isValidOpt(opts.number.gender, [ 'm', 'f' ])
     || !isValidOpt(opts.number.decimal, [ 'formal', 'informal' ])
@@ -82,7 +84,7 @@ export default (num, opts) => {
   if (opts.mode === 'currency') {
     const iso = opts.currency.type
     const locale = opts.locale
-    const numText = writeCurrency(iso, locale, integer, decimal)
+    const numText = writeCurrency(iso, locale, integer, decimal, opts.scale)
 
     return isNegative
       ? toNegative(numText, opts.negative)
@@ -92,7 +94,7 @@ export default (num, opts) => {
   if (opts.mode === 'number') {
     const intNameSingular = opts.number.gender === 'f' ? 'inteira' : 'inteiro'
     const intName = parseInt(integer) === 1 ? intNameSingular : `${intNameSingular}s`
-    const intText = writeInt(integer, opts.locale, opts.number.gender)
+    const intText = writeInt(integer, opts.locale, opts.number.gender, opts.scale)
     const decText = writeDecimal(decimal, opts.locale, opts.number.decimal)
 
     // Se tem a parte inteira e não tem a parte decimal

--- a/src/write-all.test.js
+++ b/src/write-all.test.js
@@ -41,6 +41,17 @@ test('Deve escrever valores monetários por extenso', (t) => {
   t.is(writeAll('100', { mode: 'currency', currency: { type: 'EUR' } }), 'cem euros')
 })
 
+test('Deve escrever conforme a escala desejada', (t) => {
+  t.is(writeAll('2.000.000.001', { scale: 'short' }), 'dois bilhões e um')
+  t.is(writeAll('2.000.000.001', { scale: 'short', number: { gender: 'f' } }), 'duas bilhões e uma')
+  t.is(writeAll('2.000.000.001', { scale: 'long' }), 'dois mil milhões e um')
+  t.is(writeAll('2.000.000.001', { scale: 'long', number: { gender: 'f' } }), 'duas mil milhões e uma')
+
+  // "de reais"???
+  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'short' }), 'dois bilhões e um de reais')
+  t.is(writeAll('2.000.000.001', { mode: 'currency', scale: 'long' }), 'dois mil milhões e um de reais')
+})
+
 test('Deve verificar se uma opção é válida', (t) => {
   t.true(isValidOpt('foo', [ 'foo', 'bar', 'baz' ]))
   t.false(isValidOpt('bar', [ 'foo', 'baz' ]))

--- a/src/write-currency/index.js
+++ b/src/write-currency/index.js
@@ -49,7 +49,7 @@ export const isZero = (val) => {
  * @param {string} [subunit='0'] Sub-unidade do valor (parte "decimal").
  * @returns {string} Valor escrito por extenso.
  */
-export default (iso, locale, unit = '0', subunit = '0') => {
+export default (iso, locale, unit='0', subunit='0', scale) => {
   if (!isValidIso(iso, allCurrencies)) {
     throw new Error('Invalid ISO code')
   }
@@ -59,7 +59,7 @@ export default (iso, locale, unit = '0', subunit = '0') => {
   }
 
   const opts = allCurrencies[iso]
-  const unitText = write(unit, locale, opts)
+  const unitText = write(unit, locale, scale, opts)
   const subunitText = writeSubunit(subunit, locale, opts)
 
   if (isZero(unit)) return subunitText

--- a/src/write-currency/index.js
+++ b/src/write-currency/index.js
@@ -59,7 +59,7 @@ export default (iso, locale, unit='0', subunit='0', scale) => {
   }
 
   const opts = allCurrencies[iso]
-  const unitText = write(unit, locale, scale, opts)
+  const unitText = write(unit, locale, opts, scale)
   const subunitText = writeSubunit(subunit, locale, opts)
 
   if (isZero(unit)) return subunitText

--- a/src/write-currency/write.js
+++ b/src/write-currency/write.js
@@ -9,7 +9,7 @@ import writeInt from '../write-int'
  * @param {object} opts As opções de escrita do valor.
  * @returns {string} O valor escrito por extenso.
  */
-export default (val, locale, scale, opts) => {
+export default (val, locale, opts, scale) => {
   const number = parseInt(val)
   const text = writeInt(val, locale, 'm', scale)
 

--- a/src/write-currency/write.js
+++ b/src/write-currency/write.js
@@ -9,9 +9,9 @@ import writeInt from '../write-int'
  * @param {object} opts As opções de escrita do valor.
  * @returns {string} O valor escrito por extenso.
  */
-export default (val, locale, opts) => {
+export default (val, locale, scale, opts) => {
   const number = parseInt(val)
-  const text = writeInt(val, locale)
+  const text = writeInt(val, locale, 'm', scale)
 
   if (number === 1) return `${text} ${opts.singular}`
   if (number >= 1e+6) return `${text} de ${opts.plural}`

--- a/src/write-int.js
+++ b/src/write-int.js
@@ -26,13 +26,13 @@ export const toFemale = (num) => {
  * @param {string} [gender='m'] A opção do gênero do número.
  * @returns {string} O número escrito.
  */
-export default (int, locale, gender = 'm') => {
+export default (int, locale, gender='m', scale='short') => {
   const intNum = parseInt(int)
   let num
 
   if (intNum < 1000) num = lt1000(intNum, locale)
   if (intNum === 1000) num = 'mil'
-  if (intNum > 1000) num = gt1000(int, locale)
+  if (intNum > 1000) num = gt1000(int, locale, scale)
 
   return gender === 'f'
     ? toFemale(num)

--- a/src/write-int.test.js
+++ b/src/write-int.test.js
@@ -14,6 +14,7 @@ test('Deve passar os números para o feminino', (t) => {
  */
 test('Deve escrever números inteiros', (t) => {
   t.is(writeInt('1', 'br'),       'um')
+  t.is(writeInt('1', 'br', 'f'),  'uma')
   t.is(writeInt('10', 'br'),      'dez')
   t.is(writeInt('19', 'br'),      'dezenove')
   t.is(writeInt('19', 'pt'),      'dezanove')
@@ -24,4 +25,9 @@ test('Deve escrever números inteiros', (t) => {
   t.is(writeInt('1000001', 'br'), 'um milhão e um')
   t.is(writeInt('2000000', 'br'), 'dois milhões')
   t.is(writeInt('2000001', 'br'), 'dois milhões e um')
+
+  t.is(writeInt('2000000001', 'br'),                'dois bilhões e um')
+  t.is(writeInt('2000000001', 'br', null, 'short'), 'dois bilhões e um')
+  t.is(writeInt('2000000001', 'pt', null, 'short'), 'dois biliões e um')
+  t.is(writeInt('2000000001', 'br', null, 'long'),  'dois mil milhões e um')
 })


### PR DESCRIPTION
*Referente a issue #19 e PR #23*

***

Fiz um implementação diferente (da PR #23) para a adição da opção para escala curta e longa.

As definições da escala é feita diretamente na lista dos números (em [`src/get-list.js`](https://github.com/theuves/extenso.js/commit/ffcd79e1b298d2620c734dff03d9d4fa602011fa#diff-f45296cbed3bd176dc192afa6e64c194)).

A escala curta é padrão no português brasileiro (idioma padrão dessa biblioteca).

Nessa implementação a escala longa NÃO É A PADRÃO para o português de Portugal.

## Nomenclatura

- `short` - curta (padrão)
- `long` - longa

## Exemplo

```js
extenso('2.000.000.001') // 'dois bilhões e um'
extenso('2.000.000.001', { scale: 'short' }) // 'dois bilhões e um'
extenso('2.000.000.001', { scale: 'long' }) // 'dois mil milhões e um'
```